### PR TITLE
* fix CI to avoid publishin on non-master branches

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -34,6 +34,7 @@ jobs:
         yarn build-browser
     - run: yarn test
     - name: Bump
+      if: github.ref == 'refs/heads/master'
       run: | 
         git config user.email "elya.livshitz@gmail.com"
         git config user.name "Elya Livshitz"

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
         yarn build
         yarn build-browser
     - run: yarn test
-    - name: Bump
+    - name: Bump & Publish
       if: github.ref == 'refs/heads/master'
       run: | 
         git config user.email "elya.livshitz@gmail.com"


### PR DESCRIPTION
CI did not exclude non-master branches for publish step, for example here: https://github.com/Livshitz/di.libx.js/actions/runs/505858672