### PR TITLE
ci: raise Node matrix 12.x -> 24.x

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x]
+                node-version: [24.x]
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
Same root cause as ts-reflector: no `yarn.lock` (repo ships `bun.lock`), so `yarn --frozen-lockfile` re-resolves latest transitives every run. `node-releases@2.0.53` declares `engines.node: >=18` and yarn 1 errors on engine mismatch -> install failed on 12.x.

Fix: bump the single-entry matrix to 24.x. No source/dep changes. Verified locally on Node 20/22/24: install + build + test pass; `yarn build-browser` (master-only step, not covered by this PR run) also verified on Node 24.