### PR TITLE
ci: install from the committed bun.lock; pin pax.libx.js

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,7 +27,13 @@ jobs:
                   node-version: ${{ matrix.node-version }}
                   registry-url: 'https://registry.npmjs.org'
                   scope: '@octocat' # Defaults to the user or organization that owns the workflow file:
-            - run: yarn --frozen-lockfile
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+            # Install from the COMMITTED bun.lock. `yarn --frozen-lockfile` was a no-op here (no yarn.lock ->
+            # "info No lockfile found."), so every CI run re-resolved every ^ range to latest and the build was
+            # not reproducible. Scripts still run under yarn; only the install step changed.
+            - run: bun install --frozen-lockfile
             - name: Build
               run: |
                   yarn build

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "author": "",
     "scripts": {
         "build": "tsc",
-        "build-browser": "npx -p pax.libx.js pax-browserify src/browser.ts dist -y --minify",
+        "build-browser": "npx -p pax.libx.js@0.6.28 pax-browserify src/browser.ts dist -y --minify",
         "watch": "tsc -w",
         "main": "node build/Main.js",
         "test": "jest",


### PR DESCRIPTION
CI ran `yarn --frozen-lockfile` with no yarn.lock present -> `info No lockfile found.`, so every run re-resolved every `^` range to latest (that's how node-releases@2.0.53 broke the pinned Node matrix). Install with bun from the committed bun.lock instead; build/test still run under yarn. Also pins the unpinned `npx -p pax.libx.js` in build-browser to 0.6.28. Publish lane untouched.